### PR TITLE
Profile vm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ option(BUILD_WITH_GRAPHVIZ              "Generate dependency graphs" ON)
 
 set(APPNAME			"Pharo"         CACHE STRING                 "VM Application name")
 set(FLAVOUR			"CoInterpreter" CACHE STRING                 "The kind of VM to generate. Possible values: StackVM, CoInterpreter")
+set(PROFILE			"None" CACHE STRING                 "What do you want to profile? Possible values: None, Bytecode")
 set(PHARO_LIBRARY_PATH		"@executable_path/Plugins" CACHE STRING      "The RPATH to use in the build")
 set(ICEBERG_DEFAULT_REMOTE	"scpUrl"        CACHE STRING                 "If Iceberg uses HTTPS (httpsUrl) or tries first with SSH (scpUrl)")
 set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
@@ -308,6 +309,12 @@ else()
 	set(DEBUGVM 0)
 endif()
 
+if (PROFILE MATCHES "Bytecode")
+	set(PROFILEBYTECODEVM 1)
+else()
+	set(PROFILEBYTECODEVM 0)
+endif()
+
 add_compile_options(
 	${OPTIMIZATION_LEVEL}
     -Wno-sometimes-uninitialized
@@ -332,6 +339,7 @@ add_compile_options(
 
 add_compile_definitions(
     IMMUTABILITY=1
+    PROFILE_CURRENT_BYTECODE=${PROFILEBYTECODEVM}
     COGMTVM=0
     PharoVM=1
     DEBUGVM=${DEBUGVM}

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -12302,7 +12302,11 @@ StackInterpreter >> printProcsOnList: procList [
 
 { #category : #'debug printing' }
 StackInterpreter >> printSends [
-	^false
+
+	^ self
+		  cppIf: #PROFILE_CURRENT_BYTECODE
+		  ifTrue: [ true ]
+		  ifFalse: [ false ]
 ]
 
 { #category : #'debug printing' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -2648,7 +2648,10 @@ StackInterpreter >> booleanCheatFalseV4 [
 StackInterpreter >> booleanCheatSistaV1: cond [
 	"cheat the interpreter out of the pleasure of handling the next bytecode IFF it is a jump-on-boolean. Which it is, often enough when the current bytecode is something like bytecodePrimEqual"
 	<inline: true>
-
+	
+	lkupClassTag := 1. "Integer"
+	self print: '(boolean cheat)'.
+	self doRecordSendTrace.
 	cond
 		ifTrue: [self booleanCheatTrueSistaV1]
 		ifFalse: [self booleanCheatFalseSistaV1]
@@ -2984,14 +2987,16 @@ StackInterpreter >> bytecodePrimEqualSistaV1 [
 	| rcvr arg aBool |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
+
+	messageSelector := self specialSelector: 6.
+	argumentCount := 1.
+
 	(objectMemory areIntegers: rcvr and: arg) ifTrue: [^self booleanCheatSistaV1: rcvr = arg].
 
 	self initPrimCall.
 	aBool := self primitiveFloatEqual: rcvr toArg: arg.
 	self successful ifTrue: [^self booleanCheatSistaV1: aBool].
 
-	messageSelector := self specialSelector: 6.
-	argumentCount := 1.
 	self normalSend
 ]
 
@@ -3036,6 +3041,10 @@ StackInterpreter >> bytecodePrimGreaterOrEqualSistaV1 [
 	| rcvr arg aBool |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
+
+	messageSelector := self specialSelector: 5.
+	argumentCount := 1.
+
 	(objectMemory areIntegers: rcvr and: arg) ifTrue:
 		["The C code can avoid detagging since tagged integers are still signed.
 		 But this means the simulator must override to do detagging."
@@ -3046,8 +3055,6 @@ StackInterpreter >> bytecodePrimGreaterOrEqualSistaV1 [
 	aBool := self primitiveFloatGreaterOrEqual: rcvr toArg: arg.
 	self successful ifTrue: [^self booleanCheatSistaV1: aBool].
 
-	messageSelector := self specialSelector: 5.
-	argumentCount := 1.
 	self normalSend
 ]
 
@@ -3096,6 +3103,10 @@ StackInterpreter >> bytecodePrimGreaterThanSistaV1 [
 	| rcvr arg aBool |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
+
+	messageSelector := self specialSelector: 3.
+	argumentCount := 1.
+
 	(objectMemory areIntegers: rcvr and: arg) ifTrue:
 		["The C code can avoid detagging since tagged integers are still signed.
 		 But this means the simulator must override to do detagging."
@@ -3106,8 +3117,6 @@ StackInterpreter >> bytecodePrimGreaterThanSistaV1 [
 	aBool := self primitiveFloatGreater: rcvr thanArg: arg.
 	self successful ifTrue: [^self booleanCheatSistaV1: aBool].
 
-	messageSelector := self specialSelector: 3.
-	argumentCount := 1.
 	self normalSend
 ]
 
@@ -3148,6 +3157,10 @@ StackInterpreter >> bytecodePrimIdenticalSistaV1 [
 	| rcvr arg |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
+
+	messageSelector := self specialSelector: 8.
+	argumentCount := 1.
+
 	(objectMemory isOopForwarded: rcvr) ifTrue:
 		[rcvr := self handleSpecialSelectorSendFaultFor: rcvr].
 	(objectMemory isOopForwarded: arg) ifTrue:
@@ -3192,6 +3205,10 @@ StackInterpreter >> bytecodePrimLessOrEqualSistaV1 [
 	| rcvr arg aBool |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
+
+	messageSelector := self specialSelector: 4.
+	argumentCount := 1.
+
 	(objectMemory areIntegers: rcvr and: arg) ifTrue:
 		["The C code can avoid detagging since tagged integers are still signed.
 		 But this means the simulator must override to do detagging."
@@ -3202,8 +3219,6 @@ StackInterpreter >> bytecodePrimLessOrEqualSistaV1 [
 	aBool := self primitiveFloatLessOrEqual: rcvr toArg: arg.
 	self successful ifTrue: [^self booleanCheatSistaV1: aBool].
 
-	messageSelector := self specialSelector: 4.
-	argumentCount := 1.
 	self normalSend
 ]
 
@@ -3252,6 +3267,10 @@ StackInterpreter >> bytecodePrimLessThanSistaV1 [
 	| rcvr arg aBool |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
+
+	messageSelector := self specialSelector: 2.
+	argumentCount := 1.
+
 	(objectMemory areIntegers: rcvr and: arg) ifTrue:
 		["The C code can avoid detagging since tagged integers are still signed.
 		 But this means the simulator must override to do detagging."
@@ -3262,8 +3281,6 @@ StackInterpreter >> bytecodePrimLessThanSistaV1 [
 	aBool := self primitiveFloatLess: rcvr thanArg: arg.
 	self successful ifTrue: [^ self booleanCheatSistaV1: aBool].
 
-	messageSelector := self specialSelector: 2.
-	argumentCount := 1.
 	self normalSend
 ]
 
@@ -3406,14 +3423,16 @@ StackInterpreter >> bytecodePrimNotEqualSistaV1 [
 	| rcvr arg aBool |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
+	
+	messageSelector := self specialSelector: 7.
+	argumentCount := 1.
+
 	(objectMemory areIntegers: rcvr and: arg) ifTrue: [^self booleanCheatSistaV1: rcvr ~= arg].
 
 	self initPrimCall.
 	aBool := self primitiveFloatEqual: rcvr toArg: arg.
 	self successful ifTrue: [^self booleanCheatSistaV1: aBool not].
 
-	messageSelector := self specialSelector: 7.
-	argumentCount := 1.
 	self normalSend
 ]
 
@@ -3450,6 +3469,10 @@ StackInterpreter >> bytecodePrimNotIdenticalSistaV1 [
 	| rcvr arg |
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
+	
+	messageSelector := self specialSelector: 9.
+	argumentCount := 1.
+
 	(objectMemory isOopForwarded: rcvr) ifTrue:
 		[rcvr := self handleSpecialSelectorSendFaultFor: rcvr].
 	(objectMemory isOopForwarded: arg) ifTrue:

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -5907,19 +5907,21 @@ StackInterpreter >> findClassContainingMethod: meth startingAt: classObj [
 StackInterpreter >> findClassForSelector: aSelector lookupClass: startClass do: unaryBlock [
 	"Search startClass' class hierarchy looking for aSelector and if found, evaluate unaryBlock
 	 with the class where the selector is found.  Otherwise evaluate unaryBlock with nil."
+
 	| currClass classDict classDictSize i |
 	currClass := startClass.
-	[classDict := objectMemory fetchPointer: MethodDictionaryIndex ofObject: currClass.
-	 classDictSize := objectMemory numSlotsOf: classDict.
-	 i := SelectorStart.
-	 [i < classDictSize] whileTrue:
-		[aSelector = (objectMemory fetchPointer: i ofObject: classDict) ifTrue:
-			[^unaryBlock value: currClass].
-			i := i + 1].
-	 currClass := self superclassOf: currClass.
-	 currClass = objectMemory nilObject] whileFalse.
-	^unaryBlock value: nil    "selector not found in superclass chain"
-		
+	[ currClass = objectMemory nilObject ] whileFalse: [
+		classDict := objectMemory
+			             fetchPointer: MethodDictionaryIndex
+			             ofObject: currClass.
+		classDictSize := objectMemory numSlotsOf: classDict.
+		i := SelectorStart.
+		[ i < classDictSize ] whileTrue: [
+			aSelector = (objectMemory fetchPointer: i ofObject: classDict)
+				ifTrue: [ ^ unaryBlock value: currClass ].
+			i := i + 1 ].
+		currClass := self superclassOf: currClass ].
+	^ unaryBlock value: nil "selector not found in superclass chain"
 ]
 
 { #category : #'debug support' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -3158,7 +3158,7 @@ StackInterpreter >> bytecodePrimIdenticalSistaV1 [
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
 
-	messageSelector := self specialSelector: 8.
+	messageSelector := self specialSelector: 22.
 	argumentCount := 1.
 
 	(objectMemory isOopForwarded: rcvr) ifTrue:
@@ -3470,7 +3470,7 @@ StackInterpreter >> bytecodePrimNotIdenticalSistaV1 [
 	rcvr := self stackValue: 1.
 	arg := self stackValue: 0.
 	
-	messageSelector := self specialSelector: 9.
+	messageSelector := self specialSelector: 24.
 	argumentCount := 1.
 
 	(objectMemory isOopForwarded: rcvr) ifTrue:

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -12550,7 +12550,8 @@ StackInterpreter >> profileCurrentBytecode [
 	<inline: true>
 	self cppIf: #PROFILE_CURRENT_BYTECODE ifTrue: [
 		self printNum: currentBytecode.
-		self cr ]
+		self cr.
+		self flush ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -4892,9 +4892,9 @@ StackInterpreter >> currentBytecode: anInteger [
 
 	<inline: true>
 	currentBytecode := anInteger.
+	
+	self profileCurrentBytecode
 
-	self printNum: currentBytecode.
-	self cr
 ]
 
 { #category : #initialization }
@@ -12538,6 +12538,15 @@ StackInterpreter >> processesInProcessListDo: aBlock [
 					        withInitialValue: ctxt ].
 			(self isLiveContext: ctxt) ifTrue: [ aBlock value: proc ].
 			proc := objectMemory fetchPointer: NextLinkIndex ofObject: proc ] ]
+]
+
+{ #category : #accessing }
+StackInterpreter >> profileCurrentBytecode [
+
+	<inline: true>
+	self cppIf: #PROFILE_CURRENT_BYTECODE ifTrue: [
+		self printNum: currentBytecode.
+		self cr ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -1869,7 +1869,7 @@ StackInterpreter >> activateNewMethod [
 StackInterpreter >> activeProcess [
 	"Answer the current activeProcess."
 	<api> "useful for VM debugging"
-	^objectMemory memoryActiveProcess
+	^objectMemory memoryActiveProcess 
 ]
 
 { #category : #'process primitive support' }
@@ -2598,7 +2598,7 @@ StackInterpreter >> booleanCheatFalse [
 		^ self jump: offset ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory falseObject
 ]
 
@@ -2619,7 +2619,7 @@ StackInterpreter >> booleanCheatFalseSistaV1 [
 		^ self jump: offset ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory falseObject
 ]
 
@@ -2640,7 +2640,7 @@ StackInterpreter >> booleanCheatFalseV4 [
 		^ self jump: offset ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory falseObject
 ]
 
@@ -2674,7 +2674,7 @@ StackInterpreter >> booleanCheatTrue [
 			^ self jump: offset ] ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory trueObject
 ]
 
@@ -2698,7 +2698,7 @@ StackInterpreter >> booleanCheatTrueSistaV1 [
 			^ self jump: offset ] ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory trueObject
 ]
 
@@ -2722,7 +2722,7 @@ StackInterpreter >> booleanCheatTrueV4 [
 			^ self jump: offset ] ].
 
 	"not followed by a jumpIfFalse; (un)do instruction fetch and push boolean result"
-	currentBytecode := bytecode.
+	self currentBytecode: bytecode.
 	self push: objectMemory trueObject
 ]
 
@@ -4886,6 +4886,17 @@ StackInterpreter >> currentBytecode [
 	^ currentBytecode
 ]
 
+{ #category : #accessing }
+StackInterpreter >> currentBytecode: anInteger [
+	"Use this setter to change the current bytecode, so we can profile."
+
+	<inline: true>
+	currentBytecode := anInteger.
+
+	self printNum: currentBytecode.
+	self cr
+]
+
 { #category : #initialization }
 StackInterpreter >> defaultNumStackPages [
 	"Return the default number of stack pages allocate at startup.
@@ -5793,7 +5804,7 @@ StackInterpreter >> fetchNextBytecode [
 
 	"This method fetches the next instruction (bytecode). Each bytecode method is responsible for fetching the next bytecode, preferably as early as possible to allow the memory system time to process the request before the next dispatch."
 
-	currentBytecode := self fetchByte
+	self currentBytecode: self fetchByte
 ]
 
 { #category : #'frame access' }
@@ -8387,7 +8398,7 @@ StackInterpreter >> itemporary: offset in: theFP put: valueOop [
 StackInterpreter >> jump: offset [
 
 	instructionPointer := instructionPointer + offset + 1.
-	currentBytecode := objectMemory byteAtPointer: instructionPointer
+	self currentBytecode: (objectMemory byteAtPointer: instructionPointer)
 ]
 
 { #category : #'sista bytecodes' }

--- a/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreterSimulator.class.st
@@ -415,11 +415,6 @@ StackInterpreterSimulator >> cr [
 	traceOn ifTrue: [ transcript cr; flush ].
 ]
 
-{ #category : #accessing }
-StackInterpreterSimulator >> currentBytecode: anInteger [ 
-	currentBytecode := anInteger
-]
-
 { #category : #UI }
 StackInterpreterSimulator >> desiredDisplayExtent [
 	^(savedWindowSize


### PR DESCRIPTION
Comes from https://github.com/pharo-project/pharo-vm/pull/806

This PR adds a `PROFILE` for the build of the VM to profile information and avoid overheads in production.

You can run:
```bash
cmake -DPROFILE=<profile_level> ...
```

The available values for `<profile_level>` are:
- `Bytecode`: To profile all the executed bytecodes numbers **by the interpreter**
- `None`: Default for production

------

Last session we added the _message sends_ to `-DPROFILE=Bytecode` .
We changed the implementation of the _special selectors bytecodes_ to support them.
All of this just **in the interpreter**.

### TODOs
- [ ] **Missing** profile for _look-ahead_ bytecode jump after comparisons
- [ ] **Bug** in the inlining of `currentBytecode` by Slang is introducing a bug on bytecode profiling
```c
                            /* begin fetchNextBytecode */
                            
                            currentBytecode = byteAtPointer(++local_instructionPointer);
                            
                            
#              if PROFILE_CURRENT_BYTECODE
                            {
                                printNum(40); // <-- HERE SHOULD PRINT THE NEW `currentBytecode` (current implementation always logs the "bytecode to be executed")
                                
                                print("\n");
                                flush();
                            }
#              endif /* PROFILE_CURRENT_BYTECODE */
```
- [ ] **Refactor** of `-DPROFILE` cmake option to split bytecodes and messages sends (or to keep both together and change the name of the value to `Execution`?)
- [ ] When you profile something from the terminal via `eval <expression>` it is logging all execution (even system initialization, parse of the expression by the compiler, etc.). Maybe would be nice to have a way to only profile the execution of the given expression.
- [ ] **Add** the support for GC profiling from https://github.com/pharo-project/pharo-vm/pull/606


------
_This work was made during the VMDojo sessions with many people :)_