### PR TITLE
[Experiment] Static send

### DIFF
--- a/smalltalksrc/StaticSend-Extensions/CompiledCode.extension.st
+++ b/smalltalksrc/StaticSend-Extensions/CompiledCode.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #CompiledCode }
+
+{ #category : #'*StaticSend-Extensions' }
+CompiledCode >> refersToLiteral: aLiteral [
+	"Answer true if any literal in this method is literal,
+	even if embedded in array structure."
+
+	1 to: self numLiterals - self literalsToSkip do: [ :index | "exclude selector or additional method state (penultimate slot)
+		and methodClass or outerCode (last slot)"
+		(self literalAt: index) == self ifFalse: [
+			((self literalAt: index) refersToLiteral: aLiteral) ifTrue: [
+				^ true ] ] ].
+
+	^ false
+]

--- a/smalltalksrc/StaticSend-Extensions/EncoderForSistaV1.extension.st
+++ b/smalltalksrc/StaticSend-Extensions/EncoderForSistaV1.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #EncoderForSistaV1 }
+
+{ #category : #'*StaticSend-Extensions' }
+EncoderForSistaV1 >> genSendStatic: methodLiteralOffset [ 
+	
+	stream
+		nextPut: 246;
+		nextPut: methodLiteralOffset
+]

--- a/smalltalksrc/StaticSend-Extensions/IRBuilder.extension.st
+++ b/smalltalksrc/StaticSend-Extensions/IRBuilder.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #IRBuilder }
+
+{ #category : #'*StaticSend-Extensions' }
+IRBuilder >> sendStatic: aMethod [ 
+	
+	^self add: (IRInstruction sendStatic: aMethod)
+]

--- a/smalltalksrc/StaticSend-Extensions/IRBytecodeGenerator.extension.st
+++ b/smalltalksrc/StaticSend-Extensions/IRBytecodeGenerator.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #IRBytecodeGenerator }
+
+{ #category : #'*StaticSend-Extensions' }
+IRBytecodeGenerator >> sendStatic: aMethod [
+
+	| nArgs |
+	nArgs := aMethod numArgs.
+	stack pop: nArgs.
+	encoder genSendStatic: (self literalIndexOf: aMethod)
+]

--- a/smalltalksrc/StaticSend-Extensions/IRFix.extension.st
+++ b/smalltalksrc/StaticSend-Extensions/IRFix.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #IRFix }
+
+{ #category : #'*StaticSend-Extensions' }
+IRFix >> visitStaticSend: anIRStaticSend [ 
+	
+	"Nothign"
+]

--- a/smalltalksrc/StaticSend-Extensions/IRInstruction.extension.st
+++ b/smalltalksrc/StaticSend-Extensions/IRInstruction.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #IRInstruction }
+
+{ #category : #'*StaticSend-Extensions' }
+IRInstruction class >> sendStatic: aMethod [
+
+	^ IRStaticSend new
+		  calledMethod: aMethod;
+		  yourself
+]

--- a/smalltalksrc/StaticSend-Extensions/IRMethod.extension.st
+++ b/smalltalksrc/StaticSend-Extensions/IRMethod.extension.st
@@ -1,0 +1,23 @@
+Extension { #name : #IRMethod }
+
+{ #category : #'*StaticSend-Extensions' }
+IRMethod >> generate: trailer [
+
+	| irTranslator |
+   irTranslator := IRTranslator context: compilationContext trailer: trailer.
+	irTranslator
+		visitNode: self;
+		pragmas: pragmas.
+	compiledMethod := irTranslator compiledMethod.
+	compiledMethod literals doWithIndex: [ :e :index |
+		(e isKindOf: StaticRecursiveMethodPlaceHolder)
+			ifTrue: [ compiledMethod literalAt: index put: compiledMethod ] ].
+	self sourceNode
+		ifNotNil: [
+			compiledMethod classBinding: self sourceNode methodClass binding.
+			compiledMethod selector: self sourceNode selector ]
+		ifNil: [
+			compiledMethod classBinding: UndefinedObject binding.
+			compiledMethod selector: #UndefinedMethod ].
+	^ compiledMethod
+]

--- a/smalltalksrc/StaticSend-Extensions/IRStaticSend.class.st
+++ b/smalltalksrc/StaticSend-Extensions/IRStaticSend.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #IRStaticSend,
+	#superclass : #IRInstruction,
+	#instVars : [
+		'calledMethod'
+	],
+	#category : #'StaticSend-Extensions'
+}
+
+{ #category : #visiting }
+IRStaticSend >> accept: aVisitor [
+	^ aVisitor visitStaticSend: self
+]
+
+{ #category : #accessing }
+IRStaticSend >> calledMethod [
+
+	^ calledMethod
+]
+
+{ #category : #accessing }
+IRStaticSend >> calledMethod: anObject [
+
+	calledMethod := anObject
+]

--- a/smalltalksrc/StaticSend-Extensions/IRTranslator.extension.st
+++ b/smalltalksrc/StaticSend-Extensions/IRTranslator.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #IRTranslator }
+
+{ #category : #'*StaticSend-Extensions' }
+IRTranslator >> visitStaticSend: anIRStaticSend [ 
+	
+	gen sendStatic: anIRStaticSend calledMethod
+]

--- a/smalltalksrc/StaticSend-Extensions/IRVisitor.extension.st
+++ b/smalltalksrc/StaticSend-Extensions/IRVisitor.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #IRVisitor }
+
+{ #category : #'*StaticSend-Extensions' }
+IRVisitor >> visitStaticSend: anIRStaticSend [ 
+	
+	self subclassResponsibility
+]

--- a/smalltalksrc/StaticSend-Extensions/Integer.extension.st
+++ b/smalltalksrc/StaticSend-Extensions/Integer.extension.st
@@ -1,0 +1,80 @@
+Extension { #name : #Integer }
+
+{ #category : #'*StaticSend-Extensions' }
+Integer >> lateBoundRecursiveFactorial [
+
+	<opalBytecodeMethod>
+	^ IRBuilder buildIR: [ :builder |
+		  builder
+			  pushReceiver;
+			  pushLiteral: 1;
+			  send: #'<=';
+			  jumpAheadTo: #gogogo if: false;
+
+			  "Base case"
+			  pushLiteral: 1;
+			  returnTop;
+			  
+			  "Recursive case"
+			  jumpAheadTarget: #gogogo;
+			  pushReceiver;
+			  pushReceiver;
+			  pushLiteral: 1;
+			  send: #-;
+			  send: #lateBoundRecursiveFactorial;
+			  send: #*;
+			  returnTop ]
+]
+
+{ #category : #'*StaticSend-Extensions' }
+Integer >> staticBoundRecursiveFactorial [
+
+	<opalBytecodeMethod>
+	1halt.
+	^ IRBuilder buildIR: [ :builder |
+		  builder
+			  pushReceiver;
+			  pushLiteral: 1;
+			  send: #'<=';
+			  jumpAheadTo: #gogogo if: false;
+
+			  "Base case"
+			  pushLiteral: 1;
+			  returnTop;
+			  
+			  "Recursive case"
+			  jumpAheadTarget: #gogogo;
+			  pushReceiver;
+			  pushReceiver;
+			  pushLiteral: 1;
+			  send: #-;
+			  sendStatic: (StaticRecursiveMethodPlaceHolder new selector: #staticBoundRecursiveFactorial);
+			  send: #*;
+			  returnTop ]
+]
+
+{ #category : #'*StaticSend-Extensions' }
+Integer >> staticBoundRecursiveFactorialHardcore [
+
+	<opalBytecodeMethod>
+	^ IRBuilder buildIR: [ :builder |
+		  builder
+			  pushReceiver;
+			  pushLiteral: 1;
+			  sendStatic: (SmallInteger >> #'<=');
+			  jumpAheadTo: #gogogo if: false;
+
+			  "Base case"
+			  pushLiteral: 1;
+			  returnTop;
+			  
+			  "Recursive case"
+			  jumpAheadTarget: #gogogo;
+			  pushReceiver;
+			  pushReceiver;
+			  pushLiteral: 1;
+			  sendStatic: (SmallInteger >> #'-');
+			  sendStatic: (StaticRecursiveMethodPlaceHolder new selector: #staticBoundRecursiveFactorial);
+			  sendStatic: (SmallInteger >> #'*');
+			  returnTop ]
+]

--- a/smalltalksrc/StaticSend-Extensions/StaticRecursiveMethodPlaceHolder.class.st
+++ b/smalltalksrc/StaticSend-Extensions/StaticRecursiveMethodPlaceHolder.class.st
@@ -1,0 +1,19 @@
+Class {
+	#name : #StaticRecursiveMethodPlaceHolder,
+	#superclass : #Object,
+	#instVars : [
+		'selector'
+	],
+	#category : #'StaticSend-Extensions'
+}
+
+{ #category : #accessing }
+StaticRecursiveMethodPlaceHolder >> numArgs [
+	
+	^ selector numArgs
+]
+
+{ #category : #accessing }
+StaticRecursiveMethodPlaceHolder >> selector: aString [ 
+	selector := aString
+]

--- a/smalltalksrc/StaticSend-Extensions/package.st
+++ b/smalltalksrc/StaticSend-Extensions/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'StaticSend-Extensions' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -13554,6 +13554,15 @@ StackInterpreter >> sendStaticLiteralMethodBytecode [
 	methodLiteralOffset := self fetchByte.
 	newMethod := self literal: methodLiteralOffset.
 
+	"argumentCount is used by primitives to
+	   - check how to access the stack and
+	   - know how many elements to pop,
+	and generally to check that the stack gets balanced after execution"
+	argumentCount := self argumentCountOf: newMethod.
+	
+	"primitiveFunctionPointer needs to be loaded for each method interpreted.
+	executeNewMethod: assumes that this is set during lookup
+	Thus, if we don't set it, the value will be the one of the last method/primitive called"
 	primitiveIndex := self primitiveIndexOf: newMethod.
 	primitiveFunctionPointer := self functionPointerFor: primitiveIndex inClass: nil.
 

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -749,8 +749,9 @@ StackInterpreter class >> initializeBytecodeTableForSistaV1 [
 		(243		extStoreReceiverVariableBytecode)
 		(244		extStoreLiteralVariableBytecode)
 		(245		longStoreTemporaryVariableBytecode)
+		(246		sendStaticLiteralMethodBytecode)
 
-		(246 247	unknownBytecode)
+		(247		unknownBytecode)
 
 		"3 byte bytecodes"
 		(248		callPrimitiveBytecode)
@@ -13540,6 +13541,21 @@ StackInterpreter >> sendLiteralSelector2ArgsBytecode [
 	lkupClassTag := objectMemory fetchClassTagOf: rcvr.
 	self assert: lkupClassTag ~= objectMemory nilObject.
 	self commonSendOrdinary
+]
+
+{ #category : #'send bytecodes' }
+StackInterpreter >> sendStaticLiteralMethodBytecode [
+
+	"2 Byte Bytecode
+		1st Byte: opcode
+		2nd Byte: literal offset of the method"
+
+	| methodLiteralOffset |
+	methodLiteralOffset := self fetchByte.
+	newMethod := self literal: methodLiteralOffset.
+
+	self executeNewMethod: true.
+	self fetchNextBytecode
 ]
 
 { #category : #'debug support' }

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -13550,13 +13550,12 @@ StackInterpreter >> sendStaticLiteralMethodBytecode [
 		1st Byte: opcode
 		2nd Byte: literal offset of the method"
 
-	| methodLiteralOffset rcvr |
+	| methodLiteralOffset primitiveIndex |
 	methodLiteralOffset := self fetchByte.
 	newMethod := self literal: methodLiteralOffset.
 
-	argumentCount := self argumentCountOf: newMethod.
-	rcvr := self stackValue: argumentCount.
-	lkupClassTag := objectMemory fetchClassTagOf: rcvr.
+	primitiveIndex := self primitiveIndexOf: newMethod.
+	primitiveFunctionPointer := self functionPointerFor: primitiveIndex inClass: nil.
 
 	self executeNewMethod: true.
 	self fetchNextBytecode

--- a/smalltalksrc/VMMaker/StackInterpreter.class.st
+++ b/smalltalksrc/VMMaker/StackInterpreter.class.st
@@ -13550,9 +13550,13 @@ StackInterpreter >> sendStaticLiteralMethodBytecode [
 		1st Byte: opcode
 		2nd Byte: literal offset of the method"
 
-	| methodLiteralOffset |
+	| methodLiteralOffset rcvr |
 	methodLiteralOffset := self fetchByte.
 	newMethod := self literal: methodLiteralOffset.
+
+	argumentCount := self argumentCountOf: newMethod.
+	rcvr := self stackValue: argumentCount.
+	lkupClassTag := objectMemory fetchClassTagOf: rcvr.
 
 	self executeNewMethod: true.
 	self fetchNextBytecode


### PR DESCRIPTION
Add static send bytecode, activating a given method instead of doing a lookup.
The method to activate is stored in the literal frame.

This PR for now includes:
 - the new bytecode
 - extensions to the Opal compiler to generate the bytecode
 - simple support for recursive static calls
 - examples defining a factorial method

This PR misses:
 - syntax support
 - JIT support
 - invalidation if the called method changes
 - indirect recursion support

Some small benches:

```smalltalk
[17 lateBoundRecursiveFactorial.] bench. "'2774597.961 per second'"
[17 staticBoundRecursiveFactorial.] bench.  "'3693598.280 per second'"
[17 staticBoundRecursiveFactorialHardcore.] bench. "'2170939.636 per second'"
```